### PR TITLE
Refactor query options to remove databaseName parameter

### DIFF
--- a/src/postgres.ts
+++ b/src/postgres.ts
@@ -33,15 +33,10 @@ export class PostgresClient {
 
   public async query<T extends QueryResultRow>(
     query: string,
-    options: { databaseName?: string; readonly?: boolean } = {
-      databaseName: this.pool.options.database,
+    options: { readonly?: boolean } = {
       readonly: true, // default to readonly to avoid accidental writes
     }
   ): Promise<QueryResult<T>> {
-    if (options.databaseName) {
-      this.setDatabaseInPool(options.databaseName);
-    }
-
     const client = await this.pool.connect();
 
     try {
@@ -74,10 +69,6 @@ export class PostgresClient {
 
   public getUri(tableName: string): string {
     return new URL(`${tableName}/${this.schemaName}`, this.baseUri).href;
-  }
-
-  private setDatabaseInPool(databaseName: string) {
-    this.pool.options.database = databaseName;
   }
 
   private async disconnectPool() {

--- a/src/server.ts
+++ b/src/server.ts
@@ -144,15 +144,11 @@ export class PostgresMcpServer {
     this.mcpServer.tool(
       'get-all-database-tables',
       'List all tables in the database',
-      {
-        databaseName: z.string().describe('Database name you want to list tables from'),
-      },
-      async ({ databaseName }) => {
+      {},
+      async () => {
         const query = `SELECT table_name FROM information_schema.tables WHERE table_schema = '${this.postgres.schemaName}'`;
 
-        const queryResult = await this.postgres.query(query, {
-          databaseName,
-        });
+        const queryResult = await this.postgres.query(query);
 
         return {
           content: [
@@ -177,11 +173,10 @@ export class PostgresMcpServer {
       'readonly-query',
       'Execute a read only query',
       {
-        databaseName: z.string().describe('Database name'),
         sqlQuery: z.string().describe('SQL query to execute'),
       },
-      async ({ databaseName, sqlQuery }) => {
-        const queryResult = await this.postgres.query(sqlQuery, { databaseName, readonly: true });
+      async ({ sqlQuery }) => {
+        const queryResult = await this.postgres.query(sqlQuery, { readonly: true });
 
         return {
           content: [


### PR DESCRIPTION
Simplify the query options by eliminating the databaseName parameter, streamlining the query process in the PostgresClient and PostgresMcpServer classes. This change enhances code clarity and reduces complexity.